### PR TITLE
feat: update component to work on vaadin 22+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>
@@ -13,7 +13,7 @@
     <description>Pdf Viewer component based on pdf.js library</description>
 
     <properties>
-        <vaadin.version>14.6.4</vaadin.version>
+        <vaadin.version>22.0.1</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>
@@ -18,8 +18,8 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.6.4</vaadin.version>
-        <flow.version>2.6.4</flow.version>
+        <vaadin.version>22.0.1</vaadin.version>
+        <flow.version>9.0.1</flow.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>14.6.8</vaadin.version>
+        <vaadin.version>22.0.1</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -36,7 +36,7 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.server.AbstractStreamResource;
 
 @Tag("vcf-pdf-viewer")
-@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "^0.9.3")
+@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "^1.0.0")
 @JsModule("@vaadin-component-factory/vcf-pdf-viewer/vcf-pdf-viewer.js")
 @CssImport(value = "./styles/download-button.css", themeFor = "vaadin-button")
 public class PdfViewer extends Div {


### PR DESCRIPTION
Close #4 

Web-component dependency updated to version 1.0.0.
Component Vaadin version updated to 22.0.1.
Component version updated to 2.0.0.