### PR TITLE
fix: use side-effect import instead of default import

### DIFF
--- a/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/src/pdf-print.js
+++ b/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/src/pdf-print.js
@@ -18,7 +18,7 @@
  * #L%
  */
 
-import printJS from '../print-js/dist/print.js';
+import '../print-js/dist/print.js';
 
 window.printPdf = {
 


### PR DESCRIPTION
Close #25

It seems that `dist/print.js` does not export printJS neither as a default import (_the requested module ... does not provide an export named 'default'_) nor as a named import (`import {printJS} from`...), but importing print.js [just for its side effects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only) works in both Vaadin 22 and 23.3.
