### PR TITLE
Fix for download anchor href value not updating when pdf src is changed

### DIFF
--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -46,6 +46,7 @@ public class PdfViewer extends Div {
 
   /* Indicates if download button is added or not */
   private boolean addDownloadButton = true;
+  private Anchor downloadLink;
 
   
   /* Indicates if print button is added to toolbar or not */
@@ -67,6 +68,7 @@ public class PdfViewer extends Div {
    */
   public void setSrc(String src) {
     this.getElement().setAttribute("src", src);
+    updateDownloadSource();
   }
 
   /**
@@ -79,6 +81,7 @@ public class PdfViewer extends Div {
    */
   public void setSrc(AbstractStreamResource src) {
     getElement().setAttribute("src", src);
+    updateDownloadSource();
   }
 
   /**
@@ -275,16 +278,25 @@ public class PdfViewer extends Div {
    * Adds button to download pdf file currently on display.
    */
   private void addDownloadButton() {
-    String src = this.getSrc(); 
-    Anchor link = new Anchor(src, "");   
-    link.setTabIndex(-1);    
+    String src = this.getSrc();
+    downloadLink = new Anchor(src, "");
+    downloadLink.setTabIndex(-1);
     Button downloadButton = new Button();
     downloadButton.getElement().appendChild(new Icon(VaadinIcon.DOWNLOAD).getElement());
     downloadButton.getElement().setAttribute("aria-label", "Download file");
     downloadButton.setThemeName("download-button");
-    link.add(downloadButton);
-    link.getElement().setAttribute("download", true);
-    getElement().appendChild(link.getElement());
+    downloadLink.add(downloadButton);
+    downloadLink.getElement().setAttribute("download", true);
+    getElement().appendChild(downloadLink.getElement());
+  }
+
+  /**
+   * Update the href for the download link based on the current pdf src.
+   */
+  private void updateDownloadSource() {
+    if (downloadLink != null) {
+      downloadLink.setHref(this.getSrc());
+    }
   }
 
   /**


### PR DESCRIPTION
**Issue:**
In the current version, the download Anchor's href value is only set when created, but does not get updated when the PdfViewer::setSrc methods are called.  

**Fix:**
Update anchor's href when setSrc methods are called.

**Code to Test Issue/Fix:**

```
@Route(value = "", layout = MainLayout.class)
public class ExampleView extends FlexLayout {
  
  public BasicPdfViewerExample() {
    setSizeFull();

    PdfViewer pdfViewer = new PdfViewer();
    pdfViewer.setSizeFull();
    pdfViewer.setSrc("");

    ComboBox<String> files = new ComboBox<>("Select PDF");
    files.setItems("bitcoin.pdf", "example.pdf", "example-invoice.pdf");
    files.addValueChangeListener(e -> {
      String filename = e.getValue();
      if (StringUtils.isEmpty(filename)) {
        pdfViewer.setSrc("");
        return;
      }
      try
      {
        byte[] contents = getClass().getResourceAsStream("/pdf/" + filename).readAllBytes();
        pdfViewer.setSrc(new StreamResource(filename, () -> new ByteArrayInputStream(contents)));
      } catch (Exception ex)
      {
        Notification.show("Failed to load file");
        ex.printStackTrace();
      }
    });

    add(files, pdfViewer);
    setFlexGrow(1, pdfViewer);
  }
  
}
```