### PR TITLE
Update web-component to version 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>2.7.4-SNAPSHOT</version>
+    <version>2.7.5</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.AbstractStreamResource;
 import org.apache.commons.lang3.StringUtils;
 
 @Tag("vcf-pdf-viewer")
-@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "1.4.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "1.4.2")
 @NpmPackage(value = "print-js", version = "1.6.0")
 @JsModule("@vaadin-component-factory/vcf-pdf-viewer/vcf-pdf-viewer.js")
 @JsModule("./src/pdf-print.js")


### PR DESCRIPTION
The new web-component version includes a fix for #57.

The component version was updated to 2.7.5 as 2.7.4 [already exists in directory](https://vaadin.com/directory/component/pdf-viewer/2.7.4) but there's no trace on repository.