### PR TITLE
Update web-component version to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.1</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.AbstractStreamResource;
 import org.apache.commons.lang3.StringUtils;
 
 @Tag("vcf-pdf-viewer")
-@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "3.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "3.0.2")
 @NpmPackage(value = "print-js", version = "1.6.0")
 @JsModule("@vaadin-component-factory/vcf-pdf-viewer/vcf-pdf-viewer.js")
 @JsModule("./src/pdf-print.js")


### PR DESCRIPTION
The new web-component version includes a fix for https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/57.