### PR TITLE
Allow document rotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>2.7.6-SNAPSHOT</version>
+    <version>2.7.6</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>2.7.6-SNAPSHOT</version>
+    <version>2.7.6</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>2.7.6-SNAPSHOT</version>
+    <version>2.7.6</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.AbstractStreamResource;
 import org.apache.commons.lang3.StringUtils;
 
 @Tag("vcf-pdf-viewer")
-@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "1.4.2")
+@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "1.5.0")
 @NpmPackage(value = "print-js", version = "1.6.0")
 @JsModule("@vaadin-component-factory/vcf-pdf-viewer/vcf-pdf-viewer.js")
 @JsModule("./src/pdf-print.js")

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -56,6 +56,14 @@ public class PdfViewer extends Div {
   private boolean addPrintButton = false;
   private Button printButton;
   
+  /* Indicates if Rotate Clockwise button is added to toolbar or not */
+  private boolean addRotateClockwiseButton = false;
+  private Button rotateClockwiseButton;
+  
+  /* Indicates if Rotate Counterclockwise button is added to toolbar or not */
+  private boolean addRotateCounterClockwiseButton = false;
+  private Button rotateCounterClockwiseButton;
+  
   public PdfViewer() {}
 
   /**
@@ -266,6 +274,46 @@ public class PdfViewer extends Div {
   public void hideZoom(boolean hideZoom) {
 	  this.getElement().setProperty("hideZoom", hideZoom);
   }
+  
+  /**
+   * Returns whether Rotate Clockwise button is added to the toolbar or not.
+   * 
+   * @return true if the button is added to toolbar
+   */
+  public boolean isAddRotateClockwiseButton() {
+    return addRotateClockwiseButton;
+  }
+
+  /**
+   * <p>Sets the flag to indicate if Rotate Clockwise button should be added to toolbar or not. 
+   * By default the flag is set to false, so, by default the button is not added to the toolbar. </p>
+   * <p>This flag should be set on pdf viewer initialization time.</p>
+   * 
+   * @param addRotateClockwiseButton true if rotate clockwise button should be added to toolbar
+   */
+  public void setAddRotateClockwiseButton(boolean addRotateClockwiseButton) {
+    this.addRotateClockwiseButton = addRotateClockwiseButton;
+  }
+  
+  /**
+   * Returns whether Rotate Counterclockwise button is added to the toolbar or not.
+   * 
+   * @return true if the button is added to toolbar
+   */
+  public boolean isAddRotateCounterClockwiseButton() {
+    return addRotateCounterClockwiseButton;
+  }
+
+  /**
+   * <p>Sets the flag to indicate if Rotate Counterclockwise button should be added to toolbar or not. 
+   * By default the flag is set to false, so, by default the button is not added to the toolbar. </p>
+   * <p>This flag should be set on pdf viewer initialization time.</p>
+   * 
+   * @param addRotateCounterClockwiseButton true if rotate counterclockwise button should be added to toolbar
+   */
+  public void setAddRotateCounterClockwiseButton(boolean addRotateCounterClockwiseButton) {
+    this.addRotateCounterClockwiseButton = addRotateCounterClockwiseButton;
+  }
    
   @Override
   protected void onAttach(AttachEvent attachEvent) {
@@ -275,6 +323,12 @@ public class PdfViewer extends Div {
     }
     if(addPrintButton){
       addPrintButton();
+    }
+    if(addRotateClockwiseButton){
+      addRotateClockwiseButton();
+    }
+    if(addRotateCounterClockwiseButton){
+      addRotateCounterClockwiseButton();
     }
   }
   
@@ -286,6 +340,12 @@ public class PdfViewer extends Div {
     }
     if(addPrintButton){
       this.getElement().removeChild(printButton.getElement());
+    }
+    if(addRotateClockwiseButton){
+      this.getElement().removeChild(rotateClockwiseButton.getElement());
+    }
+    if(addRotateCounterClockwiseButton){
+      this.getElement().removeChild(rotateCounterClockwiseButton.getElement());
     }
   }
 
@@ -333,4 +393,26 @@ public class PdfViewer extends Div {
     printButton.addClickListener(e -> this.getElement().executeJs("printPdf.printPdf($0)", this.getSrc()));
   }
 
+  /**
+   * Adds button to rotate pdf file clockwise.
+   */
+  private void addRotateClockwiseButton() {
+    rotateClockwiseButton = new Button(new Icon(VaadinIcon.ROTATE_RIGHT));
+    rotateClockwiseButton.getElement().setAttribute("aria-label", "Rotate clockwise");
+    rotateClockwiseButton.setThemeName("rotate-button");
+    getElement().appendChild(rotateClockwiseButton.getElement());
+    rotateClockwiseButton.addClickListener(e -> this.getElement().executeJs("this.rotateCw()"));    
+  }
+  
+  /**
+   * Adds button to rotate pdf file counterclockwise.
+   */
+  private void addRotateCounterClockwiseButton() {
+    rotateCounterClockwiseButton = new Button(new Icon(VaadinIcon.ROTATE_LEFT));
+    rotateCounterClockwiseButton.getElement().setAttribute("aria-label", "Rotate counterclockwise");
+    rotateCounterClockwiseButton.setThemeName("rotate-button");
+    getElement().appendChild(rotateCounterClockwiseButton.getElement());
+    rotateCounterClockwiseButton.addClickListener(e -> this.getElement().executeJs("this.rotateCcw()"));    
+  }
+  
 }

--- a/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/styles/toolbar-button.css
+++ b/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/styles/toolbar-button.css
@@ -1,4 +1,4 @@
-:host([theme~="download-button"]), :host([theme~="print-button"]) {
+:host([theme~="download-button"]), :host([theme~="print-button"]), :host([theme~="rotate-button"]) {
 	background: transparent;
 	color: var(--lumo-contrast-80pct);
 	min-width: 0;


### PR DESCRIPTION
This PR closes #66. Web-component version used is now [1.5.0](https://github.com/vaadin-component-factory/vcf-pdf-viewer/releases/tag/1.5.0). Buttons to rotate document clockwise and counterclockwise can be added to the toolbar. They can be added by setting to true the following flags:

```
pdfViewer.setAddRotateClockwiseButton(true);
pdfViewer.setAddRotateCounterClockwiseButton(true);    
```
   
By default the buttons are not added to the toolbar. 

The update was requested through EoD service and it was requested to target Vaadin 23 compatible version of the component. (Will be backported to Vaadin 24 compatible version later). 

The version of the component was updated to 2.7.6. Version should've incremented second digit as we're adding a new feature but version 2.8.0 was already used when a version compatible with vaadin 24 was created. To avoid confusion only last digit is updated this time.