### PR TITLE
Allow document rotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.1.0</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>

--- a/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/MainLayout.java
+++ b/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/MainLayout.java
@@ -33,11 +33,13 @@ public class MainLayout extends AppLayout {
             new RouterLink("Without zoom dropdown", WithoutZoomDropdownExample.class);
     final RouterLink sourceChangeExample =
             new RouterLink("Source change", SourceChangeExample.class);
+    final RouterLink withRotateOptionsExample =
+        new RouterLink("With rotate options", WithRotateOptionsExample.class);
 
     final VerticalLayout menuLayout = new VerticalLayout(basicExample, zoomExample,
         thumbnailsOpenExample, thumbnailsListenerExample, selectPageExample,
         customAutoFitZoomLabelsExample, withoutDownloadExample, customTitleExample, withPrintOptionExample,
-        renderingInteractiveFormsExample, withoutZoomDropdownExample, sourceChangeExample);
+        renderingInteractiveFormsExample, withoutZoomDropdownExample, sourceChangeExample, withRotateOptionsExample);
     addToDrawer(menuLayout);
     addToNavbar(drawerToggle);
   }

--- a/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/WithRotateOptionsExample.java
+++ b/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/WithRotateOptionsExample.java
@@ -1,0 +1,21 @@
+package com.vaadin.componentfactory.pdfviewer;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.StreamResource;
+
+@Route(value = "with-rotate-options", layout = MainLayout.class)
+public class WithRotateOptionsExample extends Div {
+  
+  public WithRotateOptionsExample() {
+    
+    PdfViewer pdfViewer = new PdfViewer();
+    pdfViewer.setSizeFull();
+    StreamResource resource = new StreamResource("example.pdf", () -> getClass().getResourceAsStream("/pdf/example.pdf"));
+    pdfViewer.setSrc(resource);
+    pdfViewer.setAddRotateClockwiseButton(true);
+    pdfViewer.setAddRotateCounterClockwiseButton(true);    
+    add(pdfViewer);    
+  }
+  
+}

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -56,8 +56,18 @@ public class PdfViewer extends Div {
   private boolean addPrintButton = false;
   private Button printButton;
   
+  /* Indicates if Rotate Clockwise button is added to toolbar or not */
+  private boolean addRotateClockwiseButton = false;
+  private Button rotateClockwiseButton;
+  
+  /* Indicates if Rotate Counterclockwise button is added to toolbar or not */
+  private boolean addRotateCounterClockwiseButton = false;
+  private Button rotateCounterClockwiseButton;
+  
   private String printButtonTooltipText;
   private String downloadButtonTooltipText;
+  private String rotateClockwiseButtonTooltipText;
+  private String rotateCounterClockwiseButtonTooltipText; 
   
   public PdfViewer() {}
 
@@ -360,6 +370,82 @@ public class PdfViewer extends Div {
     return downloadButtonTooltipText;
   }
 
+ /**
+   * Returns whether Rotate Clockwise button is added to the toolbar or not.
+   * 
+   * @return true if the button is added to toolbar
+   */
+  public boolean isAddRotateClockwiseButton() {
+    return addRotateClockwiseButton;
+  }
+
+  /**
+   * <p>Sets the flag to indicate if Rotate Clockwise button should be added to toolbar or not. 
+   * By default the flag is set to false, so, by default the button is not added to the toolbar. </p>
+   * <p>This flag should be set on pdf viewer initialization time.</p>
+   * 
+   * @param addRotateClockwiseButton true if rotate clockwise button should be added to toolbar
+   */
+  public void setAddRotateClockwiseButton(boolean addRotateClockwiseButton) {
+    this.addRotateClockwiseButton = addRotateClockwiseButton;
+  }
+  
+  /**
+   * Returns whether Rotate Counterclockwise button is added to the toolbar or not.
+   * 
+   * @return true if the button is added to toolbar
+   */
+  public boolean isAddRotateCounterClockwiseButton() {
+    return addRotateCounterClockwiseButton;
+  }
+
+  /**
+   * <p>Sets the flag to indicate if Rotate Counterclockwise button should be added to toolbar or not. 
+   * By default the flag is set to false, so, by default the button is not added to the toolbar. </p>
+   * <p>This flag should be set on pdf viewer initialization time.</p>
+   * 
+   * @param addRotateCounterClockwiseButton true if rotate counterclockwise button should be added to toolbar
+   */
+  public void setAddRotateCounterClockwiseButton(boolean addRotateCounterClockwiseButton) {
+    this.addRotateCounterClockwiseButton = addRotateCounterClockwiseButton;
+  }
+  
+  /**
+   * Sets tooltip text for the rotate clockwise button in toolbar.
+   * 
+   * @param rotateClockwiseButtonTooltipText the rotateClockwiseButtonTooltipText to set
+   */
+  public void setRotateClockwiseButtonTooltipText(String rotateClockwiseButtonTooltipText) {
+    this.rotateClockwiseButtonTooltipText = rotateClockwiseButtonTooltipText;
+  }
+
+  /**
+   * Returns the tooltip text defined for the rotate clockwise button.
+   * 
+   * @return the rotate clockwise button tooltip text
+   */
+  public String getRotateClockwiseButtonTooltipText() {
+    return rotateClockwiseButtonTooltipText;
+  }
+  
+  /**
+   * Sets tooltip text for the rotate counterclockwise button in toolbar.
+   * 
+   * @param rotateClockwiseButtonTooltipText the rotateClockwiseButtonTooltipText to set
+   */
+  public void setRotateCounterClockwiseButtonTooltipText(String rotateCounterClockwiseButtonTooltipText) {
+    this.rotateCounterClockwiseButtonTooltipText = rotateCounterClockwiseButtonTooltipText;
+  }
+
+  /**
+   * Returns the tooltip text defined for the rotate counterclockwise button.
+   * 
+   * @return the rotate counterclockwise button tooltip text
+   */
+  public String getRotateCounterClockwiseButtonTooltipText() {
+    return rotateCounterClockwiseButtonTooltipText;
+  }  
+
   @Override
   protected void onAttach(AttachEvent attachEvent) {
     super.onAttach(attachEvent);
@@ -368,6 +454,12 @@ public class PdfViewer extends Div {
     }
     if(addPrintButton){
       addPrintButton();
+    }
+    if(addRotateClockwiseButton){
+      addRotateClockwiseButton();
+    }
+    if(addRotateCounterClockwiseButton){
+      addRotateCounterClockwiseButton();
     }
   }
   
@@ -379,6 +471,12 @@ public class PdfViewer extends Div {
     }
     if(addPrintButton){
       this.getElement().removeChild(printButton.getElement());
+    }
+    if(addRotateClockwiseButton){
+      this.getElement().removeChild(rotateClockwiseButton.getElement());
+    }
+    if(addRotateCounterClockwiseButton){
+      this.getElement().removeChild(rotateCounterClockwiseButton.getElement());
     }
   }
 
@@ -428,4 +526,28 @@ public class PdfViewer extends Div {
     printButton.setTooltipText(this.getPrintButtonTooltipText());
   }
 
+  /**
+   * Adds button to rotate pdf file clockwise.
+   */
+  private void addRotateClockwiseButton() {
+    rotateClockwiseButton = new Button(new Icon(VaadinIcon.ROTATE_RIGHT));
+    rotateClockwiseButton.getElement().setAttribute("aria-label", "Rotate clockwise");
+    rotateClockwiseButton.setThemeName("rotate-button");
+    getElement().appendChild(rotateClockwiseButton.getElement());
+    rotateClockwiseButton.addClickListener(e -> this.getElement().executeJs("this.rotateCw()"));   
+    rotateClockwiseButton.setTooltipText(this.getRotateClockwiseButtonTooltipText());
+  }
+  
+  /**
+   * Adds button to rotate pdf file counterclockwise.
+   */
+  private void addRotateCounterClockwiseButton() {
+    rotateCounterClockwiseButton = new Button(new Icon(VaadinIcon.ROTATE_LEFT));
+    rotateCounterClockwiseButton.getElement().setAttribute("aria-label", "Rotate counterclockwise");
+    rotateCounterClockwiseButton.setThemeName("rotate-button");
+    getElement().appendChild(rotateCounterClockwiseButton.getElement());
+    rotateCounterClockwiseButton.addClickListener(e -> this.getElement().executeJs("this.rotateCcw()")); 
+    rotateCounterClockwiseButton.setTooltipText(this.getRotateCounterClockwiseButtonTooltipText());
+  }
+  
 }

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -431,7 +431,7 @@ public class PdfViewer extends Div {
   /**
    * Sets tooltip text for the rotate counterclockwise button in toolbar.
    * 
-   * @param rotateClockwiseButtonTooltipText the rotateClockwiseButtonTooltipText to set
+   * @param rotateCounterClockwiseButtonTooltipText the rotateCounterClockwiseButtonTooltipText to set
    */
   public void setRotateCounterClockwiseButtonTooltipText(String rotateCounterClockwiseButtonTooltipText) {
     this.rotateCounterClockwiseButtonTooltipText = rotateCounterClockwiseButtonTooltipText;

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.AbstractStreamResource;
 import org.apache.commons.lang3.StringUtils;
 
 @Tag("vcf-pdf-viewer")
-@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "3.0.2")
+@NpmPackage(value = "@vaadin-component-factory/vcf-pdf-viewer", version = "3.1.0")
 @NpmPackage(value = "print-js", version = "1.6.0")
 @JsModule("@vaadin-component-factory/vcf-pdf-viewer/vcf-pdf-viewer.js")
 @JsModule("./src/pdf-print.js")

--- a/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/styles/toolbar-button.css
+++ b/vcf-pdf-viewer/src/main/resources/META-INF/resources/frontend/styles/toolbar-button.css
@@ -1,4 +1,4 @@
-:host([theme~="download-button"]), :host([theme~="print-button"]) {
+:host([theme~="download-button"]), :host([theme~="print-button"]), :host([theme~="rotate-button"]) {
 	background: transparent;
 	color: var(--lumo-contrast-80pct);
 	min-width: 0;


### PR DESCRIPTION
This PR closes https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/issues/66. Web-component version used is now [3.1.0](https://github.com/vaadin-component-factory/vcf-pdf-viewer/releases/tag/3.1.0). Buttons to rotate document clockwise and counterclockwise can be added to the toolbar. They can be added by setting to true the following flags:

```
pdfViewer.setAddRotateClockwiseButton(true);
pdfViewer.setAddRotateCounterClockwiseButton(true);    
```

By default the buttons are not added to the toolbar.

The update was requested through EoD service and it was requested to target Vaadin 23 compatible version of the component. This is the backport of [that implementation](https://github.com/vaadin-component-factory/vcf-pdf-viewer-flow/pull/67).