### PR TITLE
Support new DownloadHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ pdfViewer.setSrc(resource);
 pdfViewer.openThumbnailsView();
 add(pdfViewer);    
 ```
+
+#### Since version 5.0.0 - DownloadHandler support
+```java
+PdfViewer pdfViewer = new PdfViewer();
+pdfViewer.setSrc(DownloadHandler.forClassResource(getClass(), "/pdf/example.pdf"));
+add(pdfViewer);       
+```
+
 ## Missing features or bugs
 
 You can report any issue or missing feature on [GitHub](https://github.com/vaadin-component-factory/vcf-pdf-viewer/issues).

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-root</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>vcf-pdf-viewer</module>

--- a/pom.xml
+++ b/pom.xml
@@ -12,35 +12,12 @@
     <name>Pdf Viewer</name>
     <description>Pdf Viewer component based on pdf.js library</description>
 
-    <properties>
-        <vaadin.version>24.1.12</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
     <inceptionYear>2021</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>
         <url>https://vaadin.com/</url>
     </organization>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>vcf-pdf-viewer</artifactId>
-                <version>${vcf-pdf-viewer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <type>pom</type>
-                <scope>import</scope>
-                <version>${vaadin.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    
     <repositories>
         <repository>
             <id>Vaadin Directory</id>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -18,7 +18,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.1.12</vaadin.version>
+        <vaadin.version>24.8.0</vaadin.version>
         <flow.version>9.0.1</flow.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/vcf-pdf-viewer-demo/pom.xml
+++ b/vcf-pdf-viewer-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
 
     <name>Pdf Viewer Demo</name>
     <packaging>war</packaging>

--- a/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/BasicPdfViewerExample.java
+++ b/vcf-pdf-viewer-demo/src/main/java/com/vaadin/componentfactory/pdfviewer/BasicPdfViewerExample.java
@@ -2,7 +2,7 @@ package com.vaadin.componentfactory.pdfviewer;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.streams.DownloadHandler;
 
 @Route(value = "", layout = MainLayout.class)
 public class BasicPdfViewerExample extends Div {
@@ -11,8 +11,7 @@ public class BasicPdfViewerExample extends Div {
     
     PdfViewer pdfViewer = new PdfViewer();
     pdfViewer.setSizeFull();
-    StreamResource resource = new StreamResource("example.pdf", () -> getClass().getResourceAsStream("/pdf/example.pdf"));
-    pdfViewer.setSrc(resource);
+    pdfViewer.setSrc(DownloadHandler.forClassResource(getClass(), "/pdf/example.pdf", "example.pdf"));
     add(pdfViewer);    
   }
   

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -19,7 +19,7 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.1.12</vaadin.version>
+        <vaadin.version>24.8.0</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vcf-pdf-viewer/pom.xml
+++ b/vcf-pdf-viewer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.vaadin.addons.componentfactory</groupId>
     <artifactId>vcf-pdf-viewer</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Pdf Viewer</name>

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -96,7 +96,9 @@ public class PdfViewer extends Div {
    * -&gt; getPdfInputStream("mypdf.pdf");}
    *
    * @param src stream to file
+   * @deprecated use {@link #setSrc(DownloadHandler)} instead
    */
+  @Deprecated(since = "5.0.0", forRemoval = true)
   public void setSrc(AbstractStreamResource src) {
     getElement().setAttribute("src", src);
     updateDownloadSource();

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.streams.DownloadHandler;
 import org.apache.commons.lang3.StringUtils;
 
 @Tag("vcf-pdf-viewer")
@@ -101,6 +102,18 @@ public class PdfViewer extends Div {
     updateDownloadSource();
   }
 
+  /**
+   * Sets a pdf file to render as a DownloadHandler.
+   * <p>
+   * Example: {@code DownloadHandler.forClassResource(getClass(), "mypdf.pdf")} 
+   * 
+   * @since 5.0.0
+   */
+  public void setSrc(DownloadHandler downloadHandler) {
+    getElement().setAttribute("src", downloadHandler);
+    updateDownloadSource();
+  }
+  
   /**
    * @return current zoom level
    */

--- a/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
+++ b/vcf-pdf-viewer/src/main/java/com/vaadin/componentfactory/pdfviewer/PdfViewer.java
@@ -2,7 +2,7 @@
  * #%L
  * Pdf Viewer
  * %%
- * Copyright (C) 2021 Vaadin Ltd
+ * Copyright (C) 2021 - 2025 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR introduces the following changes:

- **Added setSrc(DownloadHandler)**: Implements the new setSrc method accepting a DownloadHandler, as requested in #70.

- **Vaadin Upgrade to 24.8.0**: Required in order to support the DownloadHandler API introduced in this version.

- **Deprecated setSrc(AbstractStreamResource)**: In alignment with the [deprecation of StreamResource API in Vaadin 24.8.0](https://github.com/vaadin/flow/pull/21418), the corresponding method in this component has also been marked as deprecated.

- **Component Version Bump to 5.0.0**: Updating the Vaadin version constitutes a breaking change; therefore, the component's version has been incremented to 5.0.0.

Closes #70